### PR TITLE
Remove javascript code that makes the mermaid plots not work correctly on ReadTheDocs right now

### DIFF
--- a/docs/assets/javascripts/extra.js
+++ b/docs/assets/javascripts/extra.js
@@ -26,53 +26,6 @@ document.addEventListener('DOMContentLoaded', function() {
     observer.observe(metric);
   });
 
-  // Copy code blocks functionality
-  const codeBlocks = document.querySelectorAll('pre > code');
-  codeBlocks.forEach(block => {
-    const button = document.createElement('button');
-    button.textContent = 'Copy';
-    button.className = 'copy-button';
-    button.style.cssText = `
-      position: absolute;
-      top: 0.5rem;
-      right: 0.5rem;
-      background: var(--noaa-teal);
-      color: white;
-      border: none;
-      padding: 0.25rem 0.5rem;
-      border-radius: 0.25rem;
-      font-size: 0.75rem;
-      cursor: pointer;
-      opacity: 0;
-      transition: opacity 0.2s;
-    `;
-
-    const pre = block.parentElement;
-    pre.style.position = 'relative';
-    pre.appendChild(button);
-
-    pre.addEventListener('mouseenter', () => {
-      button.style.opacity = '1';
-    });
-
-    pre.addEventListener('mouseleave', () => {
-      button.style.opacity = '0';
-    });
-
-    button.addEventListener('click', async () => {
-      try {
-        await navigator.clipboard.writeText(block.textContent);
-        button.textContent = 'Copied!';
-        setTimeout(() => {
-          button.textContent = 'Copy';
-        }, 2000);
-      } catch (err) {
-        console.error('Failed to copy text: ', err);
-      }
-    });
-  });
-});
-
 // Smooth scrolling for anchor links
 document.addEventListener('click', function(e) {
   if (e.target.tagName === 'A' && e.target.getAttribute('href').startsWith('#')) {

--- a/docs/assets/javascripts/extra.js
+++ b/docs/assets/javascripts/extra.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', function() {
     metric.style.transition = 'opacity 0.6s ease, transform 0.6s ease';
     observer.observe(metric);
   });
+});
 
 // Smooth scrolling for anchor links
 document.addEventListener('click', function(e) {


### PR DESCRIPTION
The extra code copying button in the javascripts/extra.js file is making the mermaid plots fail to be created on the ReadTheDocs right now: https://catchem.readthedocs.io/en/latest/

There is already a feature in the material theme of mkdocs called content.code.copy that is already on as specified in the mkdocs.yml file. This one works fine with the mermaid plots since it's all consistent in the material theme and achieves the same functionality.

It looks messy to use both of these options anyway.

So let's take out the javascript code that is not working properly.
