### PR TITLE
Fix develop branch CI builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
     directory: "/" # .github/workflows
     schedule:
       interval: "monthly"
-    target-branch: "main"
+    target-branch: "develop"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (GNU)
 
 on:
   push:
@@ -24,21 +24,26 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Get Intel compilers with APT
-        if: matrix.compiler == 'ifort'
-        uses: fortran-lang/setup-fortran@v1
-        with:
-          compiler: intel-classic
-          version: "2021.9"  # oneAPI 2023.1.0
-
       - name: Install dependencies
-        if: ${{ startsWith(matrix.compiler, 'gfortran') }}
-        run: sudo apt-get update && sudo apt-get install -y libnetcdf-dev libnetcdff-dev
+        run: sudo apt-get update && sudo apt-get install -y
+          libnetcdf-dev libnetcdff-dev liblapack-dev libopenblas-dev
+
+      - name: Fetch pre-built ESMF
+        run: |
+          esmf=8.8.1-gcc-13-mpiuni
+
+          ESMF_DIR=$HOME/esmf/$esmf
+          mkdir -p $ESMF_DIR
+          cd $ESMF_DIR
+          wget https://github.com/noaa-oar-arl/gha-esmf/releases/download/v0.0.10/${esmf}.tar.gz
+          tar xzvf ${esmf}.tar.gz
+
+          echo "ESMFMKFILE=${ESMF_DIR}/lib/libO/Linux.gfortran.64.mpiuni.default/esmf.mk" >> "$GITHUB_ENV"
 
       - name: Build
         run: |
           cmake -B $BUILD_DIR
-          cmake --build $BUILD_DIR
+          cmake --build $BUILD_DIR -j2
         env:
           FC: ${{ matrix.compiler }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        compiler: [gfortran-13, gfortran-14]
+        gcc-version: ["13"]
     defaults:
       run:
         shell: bash -l {0}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Fetch pre-built ESMF
         run: |
-          esmf=8.8.1-gcc-13-mpi
+          esmf=8.8.1-gcc-${{ matrix.gcc-version }}-mpi
 
           ESMF_DIR=$HOME/esmf/$esmf
           mkdir -p $ESMF_DIR
@@ -47,7 +47,9 @@ jobs:
           cmake --build $BUILD_DIR -j2
         env:
           FC: mpifort
-          OMPI_FC: ${{ matrix.compiler }}
+          OMPI_FC: gfortran-${{ matrix.gcc-version }}
+          CC: gcc-${{ matrix.gcc-version }}
+          CXX: g++-${{ matrix.gcc-version }}
 
       - name: Test
         run: ctest --test-dir ${BUILD_DIR}/tests --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        compiler: [gfortran-12, gfortran-13, gfortran-14]
+        compiler: [gfortran-13, gfortran-14]
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  BUILD_DIR: build
+
 jobs:
   build-and-test:
     name: Build and test (${{ matrix.gcc-version }}${{ matrix.nuopc && ', NUOPC' || '' }})
@@ -21,8 +24,6 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-    env:
-      BUILD_DIR: build
 
     steps:
       - uses: actions/checkout@v6
@@ -75,3 +76,27 @@ jobs:
 
       - name: Test
         run: ctest --test-dir ${BUILD_DIR}/tests --output-on-failure
+
+  build-and-test_jcsda-docker:
+    runs-on: ubuntu-latest
+    name: Build and test (JCSDA docker image)
+    container: jcsda/docker-gnu-openmpi-dev:1.9
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Configure and build
+        run: |
+          source /opt/spack-environment/activate.sh
+          cmake -B $BUILD_DIR -DBUILD_NUOPC=ON
+          cmake --build $BUILD_DIR -j2
+
+      - name: Test
+        run: |
+          source /opt/spack-environment/activate.sh
+          ctest --test-dir ${BUILD_DIR}/tests --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Build and test
+  build-and-test:
+    name: Build and test (${{ matrix.gcc-version }}${{ matrix.nuopc && ', NUOPC' || '' }})
     runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         gcc-version: ["13"]
+        nuopc: [true, false]
+        include:
+          - gcc-version: "14"
+            nuopc: false
     defaults:
       run:
         shell: bash -l {0}
@@ -25,11 +30,18 @@ jobs:
           submodules: recursive
 
       - name: Install dependencies
+        if: ${{ !matrix.nuopc }}
+        run: sudo apt-get update && sudo apt-get install -y
+          libnetcdf-dev libnetcdff-dev
+
+      - name: Install dependencies (NUOPC)
+        if: matrix.nuopc
         run: sudo apt-get update && sudo apt-get install -y
           libnetcdf-dev libnetcdff-dev liblapack-dev libopenblas-dev
           libopenmpi-dev openmpi-bin
 
-      - name: Fetch pre-built ESMF
+      - name: Fetch pre-built ESMF (NUOPC)
+        if: matrix.nuopc
         run: |
           esmf=8.8.1-gcc-${{ matrix.gcc-version }}-mpi
 
@@ -41,15 +53,25 @@ jobs:
 
           echo "ESMFMKFILE=${ESMF_DIR}/lib/libO/Linux.gfortran.64.mpi.default/esmf.mk" >> "$GITHUB_ENV"
 
-      - name: Build
-        run: |
-          cmake -B $BUILD_DIR -DBUILD_NUOPC=ON
-          cmake --build $BUILD_DIR -j2
+      - name: Configure
+        if: ${{ !matrix.nuopc }}
+        run: cmake -B $BUILD_DIR -DBUILD_NUOPC=OFF
+        env:
+          FC: gfortran-${{ matrix.gcc-version }}
+          CC: gcc-${{ matrix.gcc-version }}
+          CXX: g++-${{ matrix.gcc-version }}
+
+      - name: Configure (NUOPC)
+        if: matrix.nuopc
+        run: cmake -B $BUILD_DIR -DBUILD_NUOPC=ON
         env:
           FC: mpifort
           OMPI_FC: gfortran-${{ matrix.gcc-version }}
           CC: gcc-${{ matrix.gcc-version }}
           CXX: g++-${{ matrix.gcc-version }}
+
+      - name: Build
+        run: cmake --build $BUILD_DIR -j2
 
       - name: Test
         run: ctest --test-dir ${BUILD_DIR}/tests --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y
           libnetcdf-dev libnetcdff-dev liblapack-dev libopenblas-dev
+          libopenmpi-dev openmpi-bin
 
       - name: Fetch pre-built ESMF
         run: |
-          esmf=8.8.1-gcc-13-mpiuni
+          esmf=8.8.1-gcc-13-mpi
 
           ESMF_DIR=$HOME/esmf/$esmf
           mkdir -p $ESMF_DIR
@@ -38,14 +39,15 @@ jobs:
           wget https://github.com/noaa-oar-arl/gha-esmf/releases/download/v0.0.10/${esmf}.tar.gz
           tar xzvf ${esmf}.tar.gz
 
-          echo "ESMFMKFILE=${ESMF_DIR}/lib/libO/Linux.gfortran.64.mpiuni.default/esmf.mk" >> "$GITHUB_ENV"
+          echo "ESMFMKFILE=${ESMF_DIR}/lib/libO/Linux.gfortran.64.mpi.default/esmf.mk" >> "$GITHUB_ENV"
 
       - name: Build
         run: |
-          cmake -B $BUILD_DIR
+          cmake -B $BUILD_DIR -DBUILD_NUOPC=ON
           cmake --build $BUILD_DIR -j2
         env:
-          FC: ${{ matrix.compiler }}
+          FC: mpifort
+          OMPI_FC: ${{ matrix.compiler }}
 
       - name: Test
         run: ctest --test-dir ${BUILD_DIR}/tests --output-on-failure

--- a/.github/workflows/ci.yml.disabled
+++ b/.github/workflows/ci.yml.disabled
@@ -9,10 +9,10 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        compiler: [gfortran-10, gfortran-11, gfortran-12]
+        compiler: [gfortran-12, gfortran-13, gfortran-14]
     defaults:
       run:
         shell: bash -l {0}
@@ -20,12 +20,12 @@ jobs:
       BUILD_DIR: build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Get Intel compilers with APT
-        if: ${{ matrix.compiler == 'ifort' }}
+        if: matrix.compiler == 'ifort'
         uses: fortran-lang/setup-fortran@v1
         with:
           compiler: intel-classic

--- a/.github/workflows/ci.yml.disabled
+++ b/.github/workflows/ci.yml.disabled
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, feature/catchem_begins]
+    branches: [main, develop]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,10 +12,10 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,8 @@ jobs:
     name: pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [main, feature/catchem_begins]
+    branches: [main, develop]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/spack-stack.yml
+++ b/.github/workflows/spack-stack.yml
@@ -52,8 +52,7 @@ jobs:
           sed "s/\[oneapi, gcc@13.13, apple-clang@14\]/\[gcc@13\]/g" catchem/ci/spack.yaml > spack_ci.yaml
           spack env create catchem-env spack_ci.yaml
           spack env activate catchem-env
-          sudo apt update
-          sudo apt install -y cmake gfortran-13 g++-13 gcc-13 libgomp1
+          sudo apt-get update && sudo apt-get install -y libgomp1
           spack compiler find
           spack external find
           # Ensure MPI with Fortran and OpenMP-capable toolchain
@@ -88,9 +87,9 @@ jobs:
           spack env activate catchem-env
           export CC=mpicc
           export FC=mpif90
-          export OMPI_CC=gcc-13
-          export OMPI_FC=gfortran-13
-          export OMPI_CXX=g++-13
+          export MPICH_CC=gcc-13
+          export MPICH_FC=gfortran-13
+          export MPICH_CXX=g++-13
           cd catchem
           mkdir -p build && cd build
           cmake -DCMAKE_INSTALL_PREFIX=../install -DBUILD_NUOPC=ON ..

--- a/.github/workflows/spack-stack.yml
+++ b/.github/workflows/spack-stack.yml
@@ -1,4 +1,4 @@
-name: CI (GNU spack-stack)
+name: CI (spack-stack)
 
 on:
   push:
@@ -14,9 +14,6 @@ defaults:
 
 env:
   cache_key: gcc
-  CC: gcc-13
-  FC: gfortran-13
-  CXX: g++-13
 
 # The jobs are split into:
 # 1. a dependency build step (setup), and
@@ -27,6 +24,7 @@ env:
 
 jobs:
   setup:
+    # NOTE: this can take quite a while if the cache misses.
     runs-on: ubuntu-24.04
 
     steps:
@@ -83,17 +81,16 @@ jobs:
             spack
             ~/.spack
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('catchem/ci/spack.yaml') }}
-      - name: Ensure HTTPS and Git dependencies
-        id: ensure-https-and-git
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git ca-certificates libcurl4-openssl-dev gfortran-13 g++-13 gcc-13
+
       - name: build
         run: |
           source spack/share/spack/setup-env.sh
           spack env activate catchem-env
           export CC=mpicc
           export FC=mpif90
+          export OMPI_CC=gcc-13
+          export OMPI_FC=gfortran-13
+          export OMPI_CXX=g++-13
           cd catchem
           mkdir -p build && cd build
           cmake -DCMAKE_INSTALL_PREFIX=../install -DBUILD_NUOPC=ON ..

--- a/.github/workflows/ubuntu_gcc.yml
+++ b/.github/workflows/ubuntu_gcc.yml
@@ -29,7 +29,7 @@ jobs:
       - name: checkout  # this is to get the ci/spack.yaml file
         uses: actions/checkout@v6
         with:
-            path: catchem
+          path: catchem
 
       # Cache spack, compiler and dependencies
       - name: cache-env
@@ -69,8 +69,8 @@ jobs:
       - name: checkout
         uses: actions/checkout@v6
         with:
-            path: catchem
-            submodules: recursive
+          path: catchem
+          submodules: recursive
 
       - name: cache-env
         id: cache-env

--- a/.github/workflows/ubuntu_gcc.yml
+++ b/.github/workflows/ubuntu_gcc.yml
@@ -1,4 +1,4 @@
-name: GCC Linux Build and Test
+name: CI (GNU spack-stack)
 on: [push, pull_request, workflow_dispatch]
 
 

--- a/.github/workflows/ubuntu_gcc.yml
+++ b/.github/workflows/ubuntu_gcc.yml
@@ -1,6 +1,10 @@
 name: CI (GNU spack-stack)
-on: [push, pull_request, workflow_dispatch]
 
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+  workflow_dispatch:
 
 # Use custom shell with -l so .bash_profile is sourced
 # without having to do it in manually every step
@@ -45,9 +49,8 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
-          git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git --branch release/2.1 --depth 1
+          git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git --branch spack-stack-1.9.3 --depth 1
           source spack/share/spack/setup-env.sh
-          export SPACK_STACK_DIR="${PWD}/spack"
           sed "s/\[oneapi, gcc@13.13, apple-clang@14\]/\[gcc@13\]/g" catchem/ci/spack.yaml > spack_ci.yaml
           spack env create catchem-env spack_ci.yaml
           spack env activate catchem-env

--- a/.github/workflows/ubuntu_gcc.yml
+++ b/.github/workflows/ubuntu_gcc.yml
@@ -47,6 +47,7 @@ jobs:
         run: |
           git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
           source spack/share/spack/setup-env.sh
+          export SPACK_STACK_DIR="${PWD}/spack"
           sed "s/\[oneapi, gcc@13.13, apple-clang@14\]/\[gcc@13\]/g" catchem/ci/spack.yaml > spack_ci.yaml
           spack env create catchem-env spack_ci.yaml
           spack env activate catchem-env

--- a/.github/workflows/ubuntu_gcc.yml
+++ b/.github/workflows/ubuntu_gcc.yml
@@ -45,7 +45,7 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
-          git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
+          git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git --branch release/2.1 --depth 1
           source spack/share/spack/setup-env.sh
           export SPACK_STACK_DIR="${PWD}/spack"
           sed "s/\[oneapi, gcc@13.13, apple-clang@14\]/\[gcc@13\]/g" catchem/ci/spack.yaml > spack_ci.yaml

--- a/.github/workflows/ubuntu_gcc.yml
+++ b/.github/workflows/ubuntu_gcc.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
       - name: checkout  # this is to get the ci/spack.yaml file
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
             path: catchem
 
       # Cache spack, compiler and dependencies
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             spack
@@ -66,14 +66,14 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
             path: catchem
             submodules: recursive
 
       - name: cache-env
         id: cache-env
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             spack

--- a/docs/developer-guide/processes/testing.md
+++ b/docs/developer-guide/processes/testing.md
@@ -535,13 +535,13 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        compiler: [gcc-9, gcc-10, gcc-11]
+        compiler: [gcc-12, gcc-13, gcc-14]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |

--- a/docs/developer-guide/processes/testing.md
+++ b/docs/developer-guide/processes/testing.md
@@ -538,14 +538,14 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        compiler: [gcc-12, gcc-13, gcc-14]
+        compiler: ["12", "13", "14"]
 
     steps:
     - uses: actions/checkout@v6
 
     - name: Install dependencies
       run: |
-        sudo apt-get install gfortran-${{ matrix.compiler }} cmake netcdf-bin libnetcdf-dev
+        sudo apt-get install libnetcdf-dev libnetcdff-dev
 
     - name: Build
       run: |


### PR DESCRIPTION
Fixed the current CI by pinning to an older spack-stack release. Also added a few other builds for variety, including the method [currently used in ACES](https://github.com/bbakernoaa/ACES/blob/dec39b35f35a640cdadda0da66785451ac8bdfa5/.github/workflows/ci.yml). Also updated Action versions.