### PR TITLE
ci: Add matrix builds for CATChem with optional MUSICA support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,16 @@ jobs:
 
   build-and-test_jcsda-docker:
     runs-on: ubuntu-latest
-    name: Build and test (JCSDA docker image)
+    name: Build and test (JCSDA docker, ${{ matrix.build-label }})
     container: jcsda/docker-gnu-openmpi-dev:1.9
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - build-label: CATChem
+            cmake-flags: -DBUILD_NUOPC=ON
+          - build-label: CATChem + MUSICA
+            cmake-flags: -DBUILD_NUOPC=ON -DBUILD_MUSICA=ON
     defaults:
       run:
         shell: bash -l {0}
@@ -93,7 +101,7 @@ jobs:
       - name: Configure and build
         run: |
           source /opt/spack-environment/activate.sh
-          cmake -B $BUILD_DIR -DBUILD_NUOPC=ON
+          cmake -B $BUILD_DIR ${{ matrix.cmake-flags }}
           cmake --build $BUILD_DIR -j2
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,9 +85,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - build-label: CATChem
+          - build-label: NUOPC
             cmake-flags: -DBUILD_NUOPC=ON
-          - build-label: CATChem + MUSICA
+          - build-label: NUOPC + MUSICA
             cmake-flags: -DBUILD_NUOPC=ON -DBUILD_MUSICA=ON
     defaults:
       run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,8 @@ repos:
       - id: gersemi
         args: [--in-place, --indent=2]
         exclude: (?x)^(
-            cmake/FindNetCDF.cmake
+            cmake/FindNetCDF.cmake|
+            src/external/yaml-cpp/.*
           )$
 
   - repo: https://github.com/codespell-project/codespell

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,20 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.21)
 
 project(CATChem VERSION 0.1.0 LANGUAGES Fortran C CXX)
 
-# Set C++ standard for yaml-cpp compatibility
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Option to build NUOPC cap (defaults to OFF)
 option(BUILD_NUOPC "Build NUOPC cap and drivers" OFF)
+
+# Option to build with MUSICA chemistry library (defaults to OFF)
+option(BUILD_MUSICA "Build with MUSICA chemistry library" OFF)
+
+# Set C++ standard — MUSICA requires C++20, yaml-cpp needs at least C++11
+if(BUILD_MUSICA)
+  set(CMAKE_CXX_STANDARD 20)
+else()
+  set(CMAKE_CXX_STANDARD 11)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(CMakePrintHelpers)
 

--- a/drivers/nuopc/catchem_nuopc_cap.F90
+++ b/drivers/nuopc/catchem_nuopc_cap.F90
@@ -273,22 +273,18 @@ contains
       type(ESMF_Info) :: tracerInfo
       type(ESMF_Field), pointer :: fieldList(:)
       type(ESMF_Clock)          :: clock
-      type(ESMF_Time)           :: currTime, startTime, stopTime
+      type(ESMF_Time)           :: startTime, stopTime
       type(ESMF_TimeInterval)   :: timeStep
       real(ESMF_KIND_R8), dimension(:,:), pointer :: coord
       real(ESMF_KIND_R8), dimension(:,:), allocatable :: lon
       real(ESMF_KIND_R8), dimension(:,:), allocatable :: lat
       type(ESMF_CoordSys_Flag)   :: coordSys
-      character(len=*), parameter :: routine = 'InitializeP2'
       real(ESMF_KIND_R8), parameter :: rad_to_deg = 180._ESMF_KIND_R8 / 3.14159265358979323846_ESMF_KIND_R8
       real(ESMF_KIND_R8) :: convet_unit
-      character(len=512) :: errmsg
       integer :: localPet, petCount
-      integer :: im, jm  ! Grid dimensions
       integer :: item, coord_item, rank, localDeCount, numLevels, localDe, localrc, stat
       integer, dimension(2) :: lb, ub
       logical :: has_tracer_array
-      type(CATChem_InternalState) :: is
 
       rc = ESMF_SUCCESS
       has_tracer_array = .false.

--- a/drivers/nuopc/catchem_nuopc_interface.F90
+++ b/drivers/nuopc/catchem_nuopc_interface.F90
@@ -188,7 +188,6 @@ contains
       type(StateManagerType), pointer :: state_mgr
       type(ConfigManagerType), pointer :: config_manager
       type(MetStateType), pointer :: met_state
-      type(ChemStateType), pointer :: chem_state
       integer :: nx, ny, num_processes, stat
       integer(ESMF_KIND_I8) :: tstep_seconds
       character(len=128), allocatable :: tracer_names(:) !< NUOPC tracer name
@@ -1061,11 +1060,9 @@ contains
       type(DiagnosticManagerType), pointer :: diag_mgr => null()
       type(ESMF_Time) :: time_on_file
       character(len=64), allocatable :: process_list(:)
-      character(len=64), allocatable :: field_names(:)
-      integer :: num_processes, num_fields, i, j
+      integer :: num_processes, i
       logical :: time_to_write
       character(len=256) :: filename
-      character(len=*), parameter :: routine = 'catchem_diagnostics_write'
 
       rc = CC_SUCCESS
 
@@ -1437,7 +1434,6 @@ contains
 
       !type(cc_wrap_type), pointer :: cc_wrap
       type(ESMF_Time) :: next_output_time
-      type(ESMF_Time) :: next_time
 
       rc = CC_SUCCESS
       time_to_write = .false.

--- a/src/api/CATChem_API.F90
+++ b/src/api/CATChem_API.F90
@@ -792,11 +792,8 @@ contains
       integer, intent(out) :: rc
 
       type(DiagnosticManagerType), pointer :: diag_mgr => null()
-      type(DiagnosticRegistryType), pointer :: registry => null()
-      character(len=64), allocatable :: process_list(:), field_names(:)
       character(len=64) :: process_name, field_name
-      integer :: num_processes, i, j, field_count, dot_pos, data_type
-      integer :: local_rc
+      integer :: local_rc, dot_pos, data_type
       real(fp) :: scalar_value
       real(fp), pointer :: array_1d_ptr(:) => null()
       real(fp), pointer :: array_2d_ptr(:,:) => null()
@@ -981,7 +978,6 @@ contains
       character(len=*), intent(in) :: var_name
       integer :: found_index
       integer :: i
-      type(ProcessManagerType), pointer :: process_mgr
 
       found_index = 0
       if (allocated(this%required_fields)) then

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -39,6 +39,18 @@ set_target_properties(
 )
 
 #
+# YAML-CPP — build first so MUSICA/TUV-x can reuse it instead of fetching their own
+#
+
+# Configure yaml-cpp build options
+set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "Build yaml-cpp tests")
+set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "Build yaml-cpp tools")
+set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "Build yaml-cpp contrib")
+
+# Use the local submodule
+add_subdirectory(yaml-cpp)
+
+#
 # MUSICA Fortran API (optional, controlled by BUILD_MUSICA)
 #
 
@@ -58,17 +70,5 @@ if(BUILD_MUSICA)
   add_subdirectory(musica)
 endif()
 
-#
-# YAML-CPP standalone build
-#
-
-# Configure yaml-cpp build options
-set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "Build yaml-cpp tests")
-set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "Build yaml-cpp tools")
-set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "Build yaml-cpp contrib")
-
-# Use the local submodule
-add_subdirectory(yaml-cpp)
-
-# Add our yaml interface (now that yaml-cpp is available independently)
+# Add our yaml interface (yaml-cpp is already available from above)
 add_subdirectory(yaml_interface)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -45,7 +45,6 @@ set_target_properties(
 if(BUILD_MUSICA)
   # Set MUSICA build options before adding the subdirectory
   set(MICM_ENABLE_TESTS OFF)
-  set(MICM_ENABLE_EXAMPLES OFF)
   set(MUSICA_BUILD_C_CXX_INTERFACE ON)
   set(MUSICA_BUILD_FORTRAN_INTERFACE ON)
   set(MUSICA_ENABLE_INSTALL OFF)

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -39,24 +39,27 @@ set_target_properties(
 )
 
 #
-# MUSICA Fortran API
+# MUSICA Fortran API (optional, controlled by BUILD_MUSICA)
 #
 
-# Set MUSICA build options before adding the subdirectory
-# set(MICM_ENABLE_TESTS OFF)
-# set(MICM_ENABLE_EXAMPLES OFF)
-# set(MUSICA_BUILD_C_CXX_INTERFACE ON)
-# set(MUSICA_BUILD_FORTRAN_INTERFACE ON)
-# set(MUSICA_ENABLE_INSTALL OFF)
-# set(MUSICA_ENABLE_TESTS OFF)
-# set(MUSICA_ENABLE_MICM ON)
-# set(MUSICA_ENABLE_TUVX ON)
+if(BUILD_MUSICA)
+  # Set MUSICA build options before adding the subdirectory
+  set(MICM_ENABLE_TESTS OFF)
+  set(MICM_ENABLE_EXAMPLES OFF)
+  set(MUSICA_BUILD_C_CXX_INTERFACE ON)
+  set(MUSICA_BUILD_FORTRAN_INTERFACE ON)
+  set(MUSICA_ENABLE_INSTALL OFF)
+  set(MUSICA_ENABLE_TESTS OFF)
+  set(MUSICA_ENABLE_MICM ON)
+  set(MUSICA_ENABLE_TUVX ON)
+  set(MUSICA_ENABLE_CARMA OFF)
 
-# # Add MUSICA as a subdirectory
-# add_subdirectory(musica)
+  # Add MUSICA as a subdirectory
+  add_subdirectory(musica)
+endif()
 
 #
-# YAML-CPP standalone build (since we're not using MUSICA)
+# YAML-CPP standalone build
 #
 
 # Configure yaml-cpp build options

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -8,8 +8,6 @@ set_target_properties(
   PROPERTIES Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/include
 )
 
-# TODO: GOCART-2G Process Library - currently disabled as source files are missing
-# Uncomment when GOCART source files are available
 #
 # GOCART-2G Process Library
 #
@@ -39,7 +37,7 @@ set_target_properties(
 )
 
 #
-# YAML-CPP — declare via FetchContent so MUSICA/TUV-x reuse it instead of fetching their own
+# yaml-cpp — declare via FetchContent so MUSICA and its dependencies reuse it
 #
 
 include(FetchContent)
@@ -50,7 +48,7 @@ set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "Build yaml-cpp tools")
 set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "Build yaml-cpp contrib")
 
 # Declare yaml-cpp as already available via FetchContent
-# This prevents MUSICA/TUV-x from fetching their own copy
+# This prevents MUSICA from fetching their own copy
 FetchContent_Declare(yaml-cpp SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/yaml-cpp)
 FetchContent_MakeAvailable(yaml-cpp)
 

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -51,10 +51,7 @@ set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "Build yaml-cpp contrib")
 
 # Declare yaml-cpp as already available via FetchContent
 # This prevents MUSICA/TUV-x from fetching their own copy
-FetchContent_Declare(
-  yaml-cpp
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/yaml-cpp
-)
+FetchContent_Declare(yaml-cpp SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/yaml-cpp)
 FetchContent_MakeAvailable(yaml-cpp)
 
 #

--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -39,16 +39,23 @@ set_target_properties(
 )
 
 #
-# YAML-CPP — build first so MUSICA/TUV-x can reuse it instead of fetching their own
+# YAML-CPP — declare via FetchContent so MUSICA/TUV-x reuse it instead of fetching their own
 #
+
+include(FetchContent)
 
 # Configure yaml-cpp build options
 set(YAML_CPP_BUILD_TESTS OFF CACHE BOOL "Build yaml-cpp tests")
 set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "Build yaml-cpp tools")
 set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "Build yaml-cpp contrib")
 
-# Use the local submodule
-add_subdirectory(yaml-cpp)
+# Declare yaml-cpp as already available via FetchContent
+# This prevents MUSICA/TUV-x from fetching their own copy
+FetchContent_Declare(
+  yaml-cpp
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/yaml-cpp
+)
+FetchContent_MakeAvailable(yaml-cpp)
 
 #
 # MUSICA Fortran API (optional, controlled by BUILD_MUSICA)

--- a/tests/test_CATChemCore.f90
+++ b/tests/test_CATChemCore.f90
@@ -5,7 +5,7 @@
 program test_CATChemCore
    use testing_mod, only: assert, assert_close
    use CATChemCore_Mod
-   use Error_Mod, only: CC_SUCCESS, CC_FAILURE, ErrorManagerType, ERROR_PROCESS_INITIALIZATION
+   use Error_Mod, only: CC_SUCCESS, ErrorManagerType
    use StateManager_Mod, only: StateManagerType
    use GridManager_Mod, only: GridManagerType
    use ProcessManager_Mod, only: ProcessManagerType

--- a/tests/test_ChemSpeciesUtils.f90
+++ b/tests/test_ChemSpeciesUtils.f90
@@ -6,7 +6,7 @@ program test_ChemSpeciesUtils
    use testing_mod, only: assert, assert_close
    use ChemSpeciesUtils_Mod
    use StateManager_Mod, only: StateManagerType
-   use Error_Mod, only: CC_SUCCESS, CC_FAILURE
+   use Error_Mod, only: CC_SUCCESS
 
    implicit none
 

--- a/tests/test_ConfigManager.f90
+++ b/tests/test_ConfigManager.f90
@@ -6,7 +6,7 @@ program test_ConfigManager
    use testing_mod, only: assert, assert_close
    use configmanager_mod, only: ConfigManagerType, ConfigPresetType, CONFIG_STRATEGY_PERMISSIVE
    use StateManager_Mod, only: StateManagerType
-   use Error_Mod, only: CC_SUCCESS, CC_FAILURE, ErrorManagerType
+   use Error_Mod, only: CC_SUCCESS, ErrorManagerType
    use GridManager_Mod, only: GridManagerType
    use ChemState_Mod, only: ChemStateType
    use Precision_Mod, only: fp

--- a/tests/test_DiagnosticManager.f90
+++ b/tests/test_DiagnosticManager.f90
@@ -6,9 +6,8 @@ program test_DiagnosticManager
    use testing_mod, only: assert, assert_close
    use DiagnosticManager_Mod
    use StateManager_Mod, only: StateManagerType
-   use Error_Mod, only: CC_SUCCESS, CC_FAILURE, ErrorManagerType
+   use Error_Mod, only: CC_SUCCESS, ErrorManagerType
    use GridManager_Mod, only: GridManagerType
-   use Precision_Mod, only: fp
 
    implicit none
 
@@ -17,7 +16,6 @@ program test_DiagnosticManager
    type(ErrorManagerType) :: error_mgr
    type(GridManagerType) :: grid_mgr
    integer :: rc
-   logical :: is_ready
 
    write(*,*) 'Testing DiagnosticManager module...'
    write(*,*) ''

--- a/tests/test_Error.f90
+++ b/tests/test_Error.f90
@@ -4,7 +4,7 @@
 !!!>
 program test_Error
    use testing_mod, only: assert, assert_close
-   use Error_Mod, only: ErrorManagerType, CC_SUCCESS, CC_FAILURE, ERROR_INVALID_INPUT
+   use Error_Mod, only: ErrorManagerType, CC_SUCCESS, ERROR_INVALID_INPUT
 
    implicit none
 

--- a/tests/test_GridManager.f90
+++ b/tests/test_GridManager.f90
@@ -6,7 +6,7 @@ program test_GridManager
    use testing_mod, only: assert, assert_close
    use GridManager_Mod, only: GridManagerType, GridGeometryType, GridDecompositionType, ColumnIteratorType, GRID_TYPE_3D, COORD_CARTESIAN
    use ColumnInterface_Mod, only: ColumnViewType
-   use Error_Mod, only: CC_SUCCESS, CC_FAILURE, ErrorManagerType
+   use Error_Mod, only: CC_SUCCESS, ErrorManagerType
    use Precision_Mod, only: fp
 
    implicit none
@@ -14,7 +14,6 @@ program test_GridManager
    type(GridManagerType) :: grid_mgr
    type(ErrorManagerType) :: error_mgr
    type(GridGeometryType) :: geometry
-   type(ColumnViewType) :: column_view
    integer :: rc
    logical :: is_ready
    integer :: nx, ny, nz

--- a/tests/test_MetState.f90
+++ b/tests/test_MetState.f90
@@ -38,9 +38,6 @@ program test_MetState
    logical, allocatable :: test_3d_logical(:,:,:)
 
    ! Verification pointers
-   real(fp), pointer :: area_ptr(:,:)
-   logical, pointer :: land_ptr(:,:)
-   integer, pointer :: lwi_ptr(:,:)
    real(fp), pointer :: temp_ptr(:)  ! For column pointer operations
 
    ! Test variables for multiple fields interface

--- a/tests/test_Precision.f90
+++ b/tests/test_Precision.f90
@@ -8,8 +8,7 @@ program test_Precision
 
    implicit none
 
-   real(fp) :: test_val
-   real(f4) :: test_f4
+   real(fp) :: test_f4
    real(f8) :: test_f8
    logical :: result
 

--- a/tests/test_ProcessFactory.f90
+++ b/tests/test_ProcessFactory.f90
@@ -6,7 +6,7 @@ program test_ProcessFactory
    use testing_mod, only: assert, assert_close
    use ProcessFactory_Mod
    use StateManager_Mod, only: StateManagerType
-   use Error_Mod, only: CC_SUCCESS, CC_FAILURE
+   use Error_Mod, only: CC_SUCCESS
    use ProcessInterface_Mod
 
    implicit none
@@ -38,7 +38,6 @@ program test_ProcessFactory
    write(*,*) 'Test 3: List available processes'
    block
       character(len=64), allocatable :: process_names(:)
-      integer :: num_processes
 
       call factory%list_available(process_names, rc)
       call assert(rc == CC_SUCCESS, "Listing available processes should succeed")

--- a/tests/test_ProcessManager.f90
+++ b/tests/test_ProcessManager.f90
@@ -6,10 +6,9 @@ program test_ProcessManager
    use testing_mod, only: assert, assert_close
    use ProcessManager_Mod
    use StateManager_Mod, only: StateManagerType
-   use Error_Mod, only: CC_SUCCESS, CC_FAILURE, ErrorManagerType
+   use Error_Mod, only: CC_SUCCESS, ErrorManagerType
    use GridManager_Mod, only: GridManagerType
    use ConfigManager_Mod, only: ConfigDataType
-   use Precision_Mod, only: fp
 
    implicit none
 
@@ -19,7 +18,6 @@ program test_ProcessManager
    type(GridManagerType) :: grid_mgr
    type(ConfigDataType) :: config_data
    integer :: rc
-   logical :: is_ready
 
    write(*,*) 'Testing ProcessManager module...'
    write(*,*) ''

--- a/tests/test_StateManager.f90
+++ b/tests/test_StateManager.f90
@@ -5,13 +5,12 @@
 program test_StateManager
    use testing_mod, only: assert, assert_close
    use StateManager_Mod
-   use Error_Mod, only: CC_SUCCESS, CC_FAILURE, ErrorManagerType, ERROR_PROCESS_INITIALIZATION
+   use Error_Mod, only: CC_SUCCESS, ErrorManagerType
    use ConfigManager_Mod, only: ConfigManagerType
    use MetState_Mod, only: MetStateType
    use ChemState_Mod, only: ChemStateType
    use GridManager_Mod, only: GridManagerType
    use DiagnosticManager_Mod, only: DiagnosticManagerType
-   use Precision_Mod, only: fp
 
    implicit none
 

--- a/tests/test_catchem_api.F90
+++ b/tests/test_catchem_api.F90
@@ -333,7 +333,7 @@ contains
       type(CATChem_Model), intent(inout) :: model
       integer, intent(inout) :: tests_total, tests_success
 
-      integer :: rc, i, current_phase
+      integer :: rc, i
       character(len=64), allocatable :: retrieved_phases(:)
       logical :: test_passed = .true.
 
@@ -573,7 +573,6 @@ contains
       integer :: rc, diag_idx
       character(len=64), allocatable :: diag_names(:), all_diag_names(:)
       real(fp), allocatable :: diag_data(:,:,:), all_diagnostic_data(:,:,:,:)
-      logical :: test_passed = .true.
 
       tests_total = tests_total + 1
 


### PR DESCRIPTION
This pull request introduces support for optionally building the project with the MUSICA chemistry library, updates the minimum required CMake version, and improves the CI workflow to test multiple build configurations. The most important changes include conditional MUSICA integration, C++ standard selection based on build options, and enhancements to the CI matrix for broader coverage.

**Build system enhancements:**

* Updated the minimum required CMake version to 3.21 in `CMakeLists.txt` to support newer features needed for conditional builds.
* Added a new `BUILD_MUSICA` option in `CMakeLists.txt` to allow optional building with the MUSICA chemistry library. The C++ standard is now set to C++20 if MUSICA is enabled, otherwise it defaults to C++11.

**MUSICA integration:**

* Added conditional logic in `src/external/CMakeLists.txt` to configure and include the MUSICA subdirectory only if `BUILD_MUSICA` is enabled, with appropriate build options set for MUSICA and its dependencies.

**Continuous Integration improvements:**

* Updated the GitHub Actions workflow in `.github/workflows/ci.yml` to use a build matrix, testing both the default build and the MUSICA-enabled build, with descriptive job names and appropriate CMake flags.
* Modified the CI build step to pass the correct CMake flags from the matrix, ensuring each configuration is built and tested as intended.