### PR TITLE
fix(build): upgrade UFS WM to spack-stack v2.1.x

### DIFF
--- a/src/external/CMakeLists.txt
+++ b/src/external/CMakeLists.txt
@@ -34,6 +34,26 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
   endif()
 endif()
 
+# The fpp preprocessor shipped with IntelLLVM 2025.2.1 miscounts macro
+# arguments in GOCART2G_MieMod.F90 ("#error: number of arguments doesn't
+# match"); 2025.3.x is fixed. Where an unaffected fpp from an earlier oneAPI
+# install exists (e.g. Gaea C6), preprocess this target with it instead —
+# same workaround the ufs-weather-model carries for its GOCART targets:
+# https://github.com/ufs-community/ufs-weather-model/issues/3213#issuecomment-4711120326
+# Remove once affected platforms move to a fixed compiler.
+set(_gocart_fpp "/opt/intel/oneapi/compiler/2025.0/bin/fpp")
+if(
+  CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM"
+  AND CMAKE_Fortran_COMPILER_VERSION VERSION_EQUAL 2025.2.1
+  AND EXISTS "${_gocart_fpp}"
+)
+  message(STATUS "GOCART2G: using ${_gocart_fpp} (IntelLLVM 2025.2.1 fpp bug)")
+  target_compile_options(
+    ${_lib}
+    PRIVATE -fpp-name=${_gocart_fpp} -Qoption,fpp,-P
+  )
+endif()
+
 #find_package(NetCDF REQUIRED COMPONENTS Fortran)
 
 # Use NetCDF from parent scope (already found by main UFS CMakeLists.txt or standalone CMakeLists.txt)


### PR DESCRIPTION
This PR contains updates to CATChem that are required for the WM upgrade to spack-stack v2.1.x (see https://github.com/ufs-community/ufs-weather-model/pull/3174). Currently, this PR includes: 
- Update to CMakeLists.txt to work around a bug in the Gaea C6 oneapi compiler. 